### PR TITLE
Added StatefulIterators_ module with parameterized type

### DIFF
--- a/src/StatefulIterators_.jl
+++ b/src/StatefulIterators_.jl
@@ -1,0 +1,114 @@
+module StatefulIterators_
+
+export StatefulIterator, available, peek, reset!
+import Base: eltype, start, next, done, read, copy
+
+type StatefulIterator{T, S}
+    iter::T
+    state::S
+end
+StatefulIterator(itr) = StatefulIterator(itr, start(itr))
+StatefulIterator(s::StatefulIterator) = StatefulIterator(s.iter, s.state)
+copy(s::StatefulIterator) = StatefulIterator(s)
+
+eltype{T,S}(::StatefulIterator{T,S}) = eltype(T) 
+eltype{T,S}(::Base.Take{StatefulIterator{T,S}}) = eltype(T)
+
+start(s::StatefulIterator) = s
+function next{T,S}(s::StatefulIterator{T,S}, ::StatefulIterator{T,S})
+    (item, s.state) = next(s.iter, s.state)
+    return item, s
+end
+done(s::StatefulIterator) = done(s.iter, s.state)
+done{T,S}(s::StatefulIterator{T,S}, ::StatefulIterator{T,S}) = done(s)
+# start(s::StatefulIterator) = start(s.iter)
+# function next{T,S}(s::StatefulIterator{T,S}, ::Int)
+#     (item, s.state) = next(s.iter, s.state)
+#     return item, s.state
+# end
+# done(s::StatefulIterator) = done(s.iter, s.state)
+# done{T,S}(s::StatefulIterator{T,S}, ::Int) = done(s.iter, s.state)
+
+
+# read{T,S}(s::StatefulIterator{T,S}) = next(s, s)[1] # does not work for tasks
+function read(s::StatefulIterator)
+    for v in s
+        return v
+    end
+end
+
+function read(s::StatefulIterator, dims::Int...)
+    a = Array(eltype(s), dims)
+    M = prod(dims)
+    if M == 0
+        return a
+    end
+    i = 0
+    for x in s
+        @inbounds a[i+=1] = x
+        if i == M
+            return a
+        end
+    end
+    return a[1:i] # Should possibly be an error. Asked for too many elements.
+end
+
+peek{T, S<:Void}(s::StatefulIterator{T,S}) = nothing # or throw exception?
+# throw(ErrorException("peek() is not supported for iterators with state of type $(S)."))
+peek{T, S}(s::StatefulIterator{T,S}) = next(s.iter, s.state)[1]
+function peek{T, S}(s::StatefulIterator{T,S}, dims::Int...)
+    state = s.state
+    a = read(s, dims...)
+    s.state = state
+    return a
+end
+
+available{T<:Base.Cycle, S}(::StatefulIterator{T, S}) = Inf
+@generated function available{T, S}(s::StatefulIterator{T,S})
+    # Returns the number of remaining bytes in stream.
+    if isbits(eltype(T)) && method_exists(length, Tuple{T}) && S <: Integer
+        if T <: Union{Array, LinSpace, UnitRange, ASCIIString}
+            # fastest algorithm for iterators that support it
+            return :((length(s.iter) - s.state + 1) * sizeof(eltype(T)))    
+        elseif T <: Range && S <: eltype(T)
+            # sometimes state is unreliable, e.g. for StepRanges
+            return :(done(s.iter, s.state) ? 0 : 
+                (length(s.iter) - findfirst(s.iter, s.state) + 1) * sizeof(eltype(T)))
+        end
+    elseif S <: Void # this is the case for tasks for example
+        return nothing
+    end
+    # fallback algorithm
+    return quote
+        state = s.state
+        siz = 0
+        for x in s
+            siz += sizeof(x)
+        end
+        s.state = state
+        return siz
+    end
+end
+
+function read{U}(s::StatefulIterator, ::Type{U})
+    N = cld(sizeof(U), sizeof(eltype(s)))
+    return reinterpret(U, read(s, N))[1]
+end
+function peek{U}(s::StatefulIterator, ::Type{U})
+    N = cld(sizeof(U), sizeof(eltype(s)))
+    return reinterpret(U, peek(s, N))[1]
+end
+function read{U}(s::StatefulIterator, ::Type{U}, dims...)
+    M = prod(dims)
+    N = cld(M * sizeof(U), sizeof(eltype(s)))
+    return reshape(resize!(reinterpret(U, read(s, N)), M), dims)
+end
+function peek{U}(s::StatefulIterator, ::Type{U}, dims...)
+    M = prod(dims)
+    N = cld(M * sizeof(U), sizeof(eltype(s)))
+    return reshape(resize!(reinterpret(U, peek(s, N)), M), dims)
+end
+
+reset!(s::StatefulIterator) = (s.state = start(s.iter))
+
+end

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -1,0 +1,106 @@
+
+using Base.Test
+using StatefulIterators_
+import StatefulIterators
+import StatefulIterators_.reset!
+import Base.read
+
+reset!(x) = nothing
+reset!(s::Union{StatefulIterators.ArrayIterator, StatefulIterators.IterIterator}) = (s.state = start(s.iter))
+
+typealias TestTypes Union{Array, ASCIIString, Range}
+
+read(x::TestTypes) = x[1]
+read(x::TestTypes, n::Int) = x[1:n]
+read(x::ASCIIString, n::Int) = collect(x[1:n]) # this must be specialized
+read(x::TestTypes, dims::Int...) = reshape(read(x, prod(dims)), dims)
+read{U}(x::TestTypes, ::Type{U}, dims...) = println("Not implemented!")
+read{U}(x::StatefulIterators.IterIterator, ::Type{U}, dims...) = println("Not implemented!")
+function read{U}(x::Array, ::Type{U}, dims...)
+    M = prod(dims)
+    N = cld(M * sizeof(U), sizeof(eltype(x)))
+    return reshape(resize!(reinterpret(U, read(x, N)), M), dims)
+end
+
+
+N = 10^6; # size of iterable
+
+function perf{T}(x::T, t::DataType)
+    println(T)
+    println("\tcollect")
+    collect(x)
+    reset!(x)
+    @time collect(x)
+    
+    println("\tread single")
+    reset!(x)
+    read(x)
+    reset!(x)
+    @time (for _ in 1:N read(x); end)
+    
+    println("\tread chunk")
+    reset!(x)
+    read(x, N)
+    reset!(x)
+    @time read(x, N)
+    
+    println("\tread reinterpret")
+    reset!(x)
+    read(x, Int8, N)
+    reset!(x)
+    @time read(x, Int8, N)
+
+    if eltype(t) <: Number
+        println("\tsum")
+        reset!(x)
+        sum(x)
+        reset!(x)
+        @time sum(x)
+    end
+    println("\n")
+end
+
+
+# Performance tests
+for A in (randn(N), 1:N, randstring(N))
+    for T in (identity, StatefulIterator, StatefulIterators.StatefulIterator)
+        perf(T(A), typeof(A))
+    end
+end
+
+
+# Correctness tests
+test_handler(r::Test.Success) = nothing
+test_handler(r::Test.Failure) = println("Test failed: $(r.expr)")
+test_handler(r::Test.Error)   = rethrow(r)
+
+Test.with_handler(test_handler) do
+    println("Correctness tests:")
+
+    T = StatefulIterator
+
+    s = T([1,2,3,4,5])
+    @test collect(take(s, 3)) == [1,2,3]
+    @test collect(take(s, 2)) == [4,5]
+
+    @test collect(T([1,2,3,4,5])) == [1,2,3,4,5]
+
+    r = 3:4:100
+    s = T(r)
+    @test collect(T(r)) == collect(r) == read(T(r), length(r)) == Int[read(s) for _ in 1:length(r)]
+
+    @test read(T([0x1,0x2,0x3,0x4,0x5])) == 0x1
+    @test read(T([0x1,0x2,0x3,0x4,0x5]), 2, 2) == [0x1 0x3; 0x2 0x4]
+    
+    @test read(T([0x1,0x2,0x3,0x4,0x5]), UInt16) == 0x0201
+    @test read(T([0x1,0x2,0x3,0x4,0x5]), UInt16, 2) == [0x0201, 0x0403]
+    @test read(T(UInt16[0x0201, 0x0403]), UInt8, 4) == [0x1,0x2,0x3,0x4]
+
+    foo() = (for i in 1:4 produce(i); end)
+    s = T(Task(foo))
+    @test collect(T(Task(foo))) == collect(Task(foo)) == read(T(Task(foo)), 4) == [read(s) for _ in 1:4]
+
+    str = randstring(100);
+    s = T(str)
+    @test collect(T(str)) == collect(str) == read(T(str), length(str)) == Char[read(s) for _ in 1:length(str)]
+end


### PR DESCRIPTION
Instead of having two or more leaf types, there is now only one parameterized type.

Performance is much better than the current IterIterable type. For the ArrayIterable it is mixed. When ArrayIterable uses pure indexing it is a few times faster, but when using the iteration protocol it is >10x slower then the proposed type.
